### PR TITLE
Report relative file names on error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ var tslintPlugin = function(pluginOptions) {
                 return cb(error, undefined);
             }
 
-            tslint = new TSLint(path.basename(file.path), file.contents.toString('utf8'), options);
+            tslint = new TSLint(file.relative, file.contents.toString('utf8'), options);
             file.tslint = tslint.lint();
 
             // Pass file


### PR DESCRIPTION
gulp-tslint often reports things like:

``` shell
(trailing-whitespace) index.ts  ....
```

which is not handy if you have multiple index.ts files.  TSLint itself reports relative paths. 
With this change, gulp-tslint does too.
