### PR TITLE
Update tslint to v2.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,7 @@ var tslintPlugin = function(pluginOptions) {
  * Convert a failure to the prose error format
  */
 var proseErrorFormat = function(failure) {
-    // line + 1 because TSLint's first line and character is 0
-    return failure.name + "[" + (failure.startPosition.line + 1) + ", " + (failure.startPosition.character + 1) + "]: " + failure.failure;
+    return failure.name + "[" + failure.startPosition.line + ", " + failure.startPosition.character + "]: " + failure.failure;
 };
 
 /*
@@ -96,8 +95,7 @@ var proseReporter = function(failures) {
 var verboseReporter = function(failures) {
     failures.forEach(function(failure) {
         console.log("(" + failure.ruleName + ") " + failure.name +
-            // +1 because TSLint's first line and character is 0
-            "[" + (failure.startPosition.line + 1) + ", " + (failure.startPosition.character + 1) + "]: " + failure.failure);
+            "[" + failure.startPosition.line + ", " + failure.startPosition.character + "]: " + failure.failure);
     });
 };
 
@@ -105,8 +103,7 @@ var verboseReporter = function(failures) {
 var fullReporter = function(failures, file) {
     failures.forEach(function(failure) {
         console.log("(" + failure.ruleName + ") " + file.path +
-            // +1 because TSLint's first line and character is 0
-            "[" + (failure.startPosition.line + 1) + ", " + (failure.startPosition.character + 1) + "]: " + failure.failure);
+            "[" + failure.startPosition.line + ", " + failure.startPosition.character + "]: " + failure.failure);
     });
 };
 
@@ -115,9 +112,9 @@ var fullReporter = function(failures, file) {
  * [{
  *   "name": "invalid.ts",
  *   "failure": "missing whitespace",
- *   // Lines and characters start from 0
- *   "startPosition": {"position": 8, "line": 0, "character": 8},
- *   "endPosition": {"position": 9, "line": 0, "character": 9},
+ *   // Lines and characters start from 1
+ *   "startPosition": {"position": 8, "line": 1, "character": 9},
+ *   "endPosition": {"position": 9, "line": 1, "character": 10},
  *   "ruleName": "one-line"
  * }]
  */

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "map-stream": "~0.1.0",
     "rcloader": "~0.1.2",
     "through": "~2.3.6",
-    "tslint": "^1.2.0"
+    "tslint": "^2.1.0"
   },
   "analyze": true,
   "devDependencies": {},

--- a/test/valid.ts
+++ b/test/valid.ts
@@ -1,1 +1,1 @@
-var test : string = "abc";
+var test : string|number = "abc";


### PR DESCRIPTION
Starting in v2 the formatters are no longer zero based.

I also had to update how the file name was supplied due to tslint crashing when a file is in a subdirectory. See https://github.com/palantir/tslint/issues/288 for more details on this.

I'll update this as needed based on the feedback in that issue.