### PR TITLE
Feature/error settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ All default options
 var options = {
     configuration: {},
     rulesDirectory: null,
-    emitError: true
+    emitError: true,
+    reportLimit: -1
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,15 @@ gulp.task('tslint-json', function(){
 });
 ```
 
+You can specify a report limit that will turn off reporting for files after the limit has been reached. If the limit is 0 or less, the limit is ignored.
+
 All default options
 ```javascript
 var options = {
     configuration: {},
     rulesDirectory: null,
     emitError: true,
-    reportLimit: -1
+    reportLimit: 0
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -178,16 +178,14 @@ tslintPlugin.report = function(reporter, options) {
             var ignoreFailureCount = 0;
 
             if (options.reportLimit > 0) {
-                var ignoreFailureStart = options.reportLimit;
                 ignoreFailureCount = allFailures.length - options.reportLimit;
-
-                failuresToOutput = allFailures.splice(ignoreFailureStart, ignoreFailureCount)
+                failuresToOutput = allFailures.slice(0, options.reportLimit)
             }
 
 
             var failureOutput = failuresToOutput.map(function(failure) {
                 return proseErrorFormat(failure);
-            }).join(', ') + '.';
+            }).join(', ');
 
             var ignoreOutput = ignoreFailureCount > 0 ? " (" + ignoreFailureCount + " other errors not shown.)" : "" ;
             return this.emit('error', new PluginError('gulp-tslint', 'Failed to lint: ' + failureOutput + '.' + ignoreOutput));

--- a/index.js
+++ b/index.js
@@ -126,12 +126,18 @@ tslintPlugin.report = function(reporter, options) {
     if (options.emitError === undefined) {
         options.emitError = true;
     }
+    if (options.reportLimit === undefined) {
+        options.reportLimit = -1;
+    }
 
     // Collect all files with errors
     var errorFiles = [];
 
     // Collect all failures
     var allFailures = [];
+
+    // Track how many errors have been reported
+    var totalReported = 0;
 
     // Run the reporter for each file individually
     var reportFailures = function(file) {
@@ -140,16 +146,23 @@ tslintPlugin.report = function(reporter, options) {
             errorFiles.push(file);
             Array.prototype.push.apply(allFailures, failures);
 
-            if (reporter === 'json') {
-                jsonReporter(failures, file, options);
-            } else if (reporter === 'prose') {
-                proseReporter(failures, file, options);
-            } else if (reporter === 'verbose') {
-                verboseReporter(failures, file, options);
-            } else if (reporter === 'full') {
-                fullReporter(failures, file, options);
-            } else if (isFunction(reporter)) {
-                reporter(failures, file, options);
+            if (options.reportLimit >= 0 && options.reportLimit > totalReported) {
+                totalReported += failures.length;
+                if (reporter === 'json') {
+                    jsonReporter(failures, file, options);
+                } else if (reporter === 'prose') {
+                    proseReporter(failures, file, options);
+                } else if (reporter === 'verbose') {
+                    verboseReporter(failures, file, options);
+                } else if (reporter === 'full') {
+                    fullReporter(failures, file, options);
+                } else if (isFunction(reporter)) {
+                    reporter(failures, file, options);
+                }
+                
+                if (options.reportLimit >= 0 && options.reportLimit <= totalReported) {
+                    console.log("More than " + options.reportLimit + " failures reported. Turning off reporter.");
+                }
             }
         }
 
@@ -161,9 +174,16 @@ tslintPlugin.report = function(reporter, options) {
     var throwErrors = function() {
         // Throw error
         if (options && options.emitError === true && errorFiles.length > 0) {
-            return this.emit('error', new PluginError('gulp-tslint', 'Failed to lint: ' + allFailures.map(function(failure) {
+            var start = options.reportLimit >= 0 ? options.reportLimit : 0;
+            var ignoreCount = options.reportLimit >= 0 ? allFailures.length - options.reportLimit : 0;
+            var failuresToOutput = allFailures.splice(start, ignoreCount);
+
+            var failureOutput = allFailures.map(function(failure) {
                 return proseErrorFormat(failure);
             }).join(', ') + '.'));
+
+            var ignoreOutput = ignoreCount > 0 ? " (" + ignoreCount + " other errors not shown.)" : "" ;
+            return this.emit('error', new PluginError('gulp-tslint', 'Failed to lint: ' + failureOutput + '.' + ignoreOutput));
         }
 
         // Notify through that we're done

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -72,6 +72,14 @@ gulp.task('invalid-noemit', function(){
         }));
 });
 
+gulp.task('invalid-report-limit', function(){
+      gulp.src(['invalid.ts', 'invalid2.ts'])
+        .pipe(tslint())
+        .pipe(tslint.report('prose', {
+            reportLimit: 2
+        }));
+});
+
 gulp.task('invalid-all', function(){
     gulp.src('invalid.ts')
         .pipe(tslint())


### PR DESCRIPTION
Added two error settings. When I turned on tslint for our project it kicked out something like 16000 errors and it was impossible to deal with. This adds a reporting cap and a way to change the default delimiter used in the error reporting.

I added tests and ran all of the existing ones and didn't see anything out of line.