### PR TITLE
Add support for using the gutil log instead of console.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,12 @@ var tslintPlugin = function(pluginOptions) {
     });
 };
 
+var gulpTslintLog = console.log;
+
+var gutilLogger = function(message) {
+    var prefix = "[" + gutil.colors.cyan("gulp-tslint") + "]";
+    gutil.log(prefix, gutil.colors.red("error"), message);
+}
 
 /*
  * Convert a failure to the prose error format
@@ -83,18 +89,18 @@ var proseErrorFormat = function(failure) {
  * Define default reporters
  */
 var jsonReporter = function(failures) {
-    console.log(JSON.stringify(failures));
+    gulpTslintLog(JSON.stringify(failures));
 };
 
 var proseReporter = function(failures) {
     failures.forEach(function(failure) {
-        console.log(proseErrorFormat(failure));
+        gulpTslintLog(proseErrorFormat(failure));
     });
 };
 
 var verboseReporter = function(failures) {
     failures.forEach(function(failure) {
-        console.log('(' + failure.ruleName + ') ' + failure.name +
+        gulpTslintLog('(' + failure.ruleName + ') ' + failure.name +
             '[' + failure.startPosition.line + ', ' + failure.startPosition.character + ']: ' + failure.failure);
     });
 };
@@ -102,7 +108,7 @@ var verboseReporter = function(failures) {
 // Like verbose, but prints full path
 var fullReporter = function(failures, file) {
     failures.forEach(function(failure) {
-        console.log('(' + failure.ruleName + ') ' + file.path +
+        gulpTslintLog('(' + failure.ruleName + ') ' + file.path +
             '[' + failure.startPosition.line + ', ' + failure.startPosition.character + ']: ' + failure.failure);
     });
 };
@@ -128,6 +134,9 @@ tslintPlugin.report = function(reporter, options) {
     }
     if (options.reportLimit === undefined) {
         options.reportLimit = 0; // 0 or less is unlimited
+    }
+    if (options.logger !== undefined && options.logger === "gutil") {
+        gulpTslintLog = gutilLogger;
     }
 
     // Collect all files with errors
@@ -161,7 +170,7 @@ tslintPlugin.report = function(reporter, options) {
                 }
 
                 if (options.reportLimit > 0 && options.reportLimit <= totalReported) {
-                    console.log('More than ' + options.reportLimit + ' failures reported. Turning off reporter.');
+                    gulpTslintLog('More than ' + options.reportLimit + ' failures reported. Turning off reporter.');
                 }
             }
         }

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -116,6 +116,24 @@ gulp.task('invalid-report-limit-thousand', function(){
         }));
 });
 
+gulp.task('invalid-logger-gutil', function(){
+      gulp.src(['invalid2.ts', 'invalid.ts'])
+        .pipe(tslint())
+        .pipe(tslint.report('prose', {
+            logger: "gutil",
+            emitError: false
+        }));
+});
+
+gulp.task('invalid-logger-gutil-emit', function(){
+      gulp.src(['invalid2.ts', 'invalid.ts'])
+        .pipe(tslint())
+        .pipe(tslint.report('prose', {
+            logger: "gutil",
+            emitError: true
+        }));
+});
+
 gulp.task('invalid-all', function(){
     gulp.src('invalid.ts')
         .pipe(tslint())


### PR DESCRIPTION
Not sure how you feel about this kind of feature (or naming; or what to put in the README) but the gist of it is that travis builds show errors more intelligently if they see gulp-util output.

The talking points:

* Is this whole thing even necessary? Should it just use gulp-util by default?
* Where should the `gulpTslintLog` method live? What should it be called?
* The default option is to use console so I only added a check for switching it to the gulp-util logger. What should that flag be called? What should the option value be? I just guessed at `logger: gutil` to start with.
* I chose to put a red `error` string for every logged message but this isn't _strictly_ correct for messages like `More than 10 failures reported. Turning off reporter.` Not sure how you feel about that.
