### PR TITLE
Updated to latest version of tslint 2.2.0-beta dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-tslint",
   "preferGlobal": false,
-  "version": "2.0.0",
+  "version": "2.1.0-beta",
   "author": "Panu Horsmalahti <panu.horsmalahti@iki.fi>",
   "description": "TypeScript linter Gulp plugin",
   "contributors": [
@@ -31,7 +31,7 @@
     "map-stream": "~0.1.0",
     "rcloader": "~0.1.4",
     "through": "~2.3.7",
-    "tslint": "~2.1.1"
+    "tslint": "~2.2.0-beta"
   },
   "analyze": true,
   "devDependencies": {},


### PR DESCRIPTION
This change is for the beta version of tslint (2.2.0-beta) which targets TypeScript version 1.5.0-beta.