### PR TITLE
added msbuild / visual studio report format

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,17 @@ var fullReporter = function(failures, file) {
     });
 };
 
+ /**
+  * MsBuild Format error reporter.
+  * @param {Array<object>} failures
+  */
+var msbuildReporter = function(failures, file) {
+	failures.forEach(function(failure) {
+		var positionTuple = "(" + (failure.startPosition.line + 1) + "," + (failure.startPosition.character + 1) + ")";
+		console.log(file.path + positionTuple + ": warning " + failure.ruleName + ": " + failure.failure);
+	});
+};
+
 /* Output is in the following form:
  * [{
  *   "name": "invalid.ts",
@@ -213,6 +224,8 @@ tslintPlugin.report = function(reporter, options) {
                     verboseReporter(failures, file, options);
                 } else if (reporter === 'full') {
                     fullReporter(failures, file, options);
+                } else if (reporter === 'msbuild') {
+                    msbuildReporter(failures, file, options);
                 } else if (isFunction(reporter)) {
                     reporter(failures, file, options);
                 }


### PR DESCRIPTION
This format helps integrate tslint errors in visual studio errors window.
When building a project using gulp via custom msbuild task, Visual Studio capture errors and warnings messages from console output to show in a specialized windows. This format alllow visual studio recognize tslint errors