### PR TITLE
Remove peer dependency?

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "tslint": "~3.0.0",
     "typescript": "latest"
   },
-  "peerDependencies": {
-    "tslint": ">=3.0.0"
-  },
   "license": "MIT",
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
When using `tslint@next`, the peer dependency declaration conflicts:

```bash
$ npm install gulp-tslint
jsoniq@0.0.1 /Users/wcandillon/tmp/jsoniq
├── gulp-tslint@4.0.0  extraneous
└── UNMET PEER DEPENDENCY tslint@3.1.0-dev.1

npm WARN EPEERINVALID gulp-tslint@4.0.0 requires a peer of tslint@>=3.0.0 but none was installed.
```