### PR TITLE
Designate optional properties as optional.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var proseErrorFormat = function (failure) {
 };
 /**
  * Main plugin function
- * @param {PluginOptions} pluginOptions contains the options for gulp-tslint.
+ * @param {PluginOptions} [pluginOptions] contains the options for gulp-tslint.
  * Optional.
  * @returns {any}
  */

--- a/index.ts
+++ b/index.ts
@@ -113,7 +113,7 @@ const proseErrorFormat = function(failure: Failure) {
 
 /**
  * Main plugin function
- * @param {PluginOptions} pluginOptions contains the options for gulp-tslint.
+ * @param {PluginOptions} [pluginOptions] contains the options for gulp-tslint.
  * Optional.
  * @returns {any}
  */


### PR DESCRIPTION
This change reduces noise in IDEs that require an argument where the argument is actually optional.