### PR TITLE
Missing custom formatter type in d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export interface PluginOptions {
     configuration?: any;
-    formatter?: string | any;
+    formatter?: string | Function;
     formattersDirectory?: string;
     rulesDirectory?: string;
     tslint?: any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export interface PluginOptions {
     configuration?: any;
-    formatter?: string;
+    formatter?: string | any;
     formattersDirectory?: string;
     rulesDirectory?: string;
     tslint?: any;


### PR DESCRIPTION
Code sample:
```ts
import * as Lint from "tslint/lib/lint";
import tslint from "gulp-tslint";

// Custom formatter class
export class Formatter extends Lint.Formatters.AbstractFormatter {
    public format(failures: Lint.RuleFailure[]): string {
        var failuresJSON = failures.map((failure: Lint.RuleFailure) => failure.toJson());
        return JSON.stringify(failuresJSON);
    }
}


gulp.task("tslint", () =>
    gulp.src("source.ts")
        .pipe(tslint({
            formatter: Formatter  // Custom formatter
        }))
        .pipe(tslint.report())
);
```