### PR TITLE
Check the linter output before writing to console.

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,9 @@ tslintPlugin.report = function (options) {
             errorFiles.push(file);
             Array.prototype.push.apply(allFailures, file.tslint.failures);
             if (options.reportLimit <= 0 || (options.reportLimit && options.reportLimit > totalReported)) {
-                console.log(file.tslint.output);
+                if (file.tslint.output !== undefined) {
+                    console.log(file.tslint.output);
+                }
                 totalReported += failureCount;
                 if (options.reportLimit > 0 &&
                     options.reportLimit <= totalReported) {

--- a/index.ts
+++ b/index.ts
@@ -204,7 +204,9 @@ tslintPlugin.report = function(options?: ReportOptions) {
             Array.prototype.push.apply(allFailures, file.tslint.failures);
 
             if (options.reportLimit <= 0 || (options.reportLimit && options.reportLimit > totalReported)) {
-                console.log(file.tslint.output);
+                if (file.tslint.output !== undefined) {
+                    console.log(file.tslint.output);
+                }
                 totalReported += failureCount;
 
                 if (options.reportLimit > 0 &&


### PR DESCRIPTION
We should write the output only to console if the formatter actually returns something meaningfull. This should fix https://github.com/panuhorsmalahti/gulp-tslint/issues/75.