### PR TITLE
add option to write tslint output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ gulp.task("tslint", () =>
 );
 ```
 
+Report output into a file
+--------------------------
+
+You can optionally specify a filename to redirect stdout into that file. If `options.out` is undefined or not of type string it is ignored and you get the output on stdout. 
+
+```javascript
+gulp.task("tslint", () =>
+    gulp.src(["input.ts",])
+        .pipe(tslint({
+            formatter: "checkstyle"
+        }))
+        .pipe(tslint.report({
+            out: "target/checkstyle-result.xml"
+        }))
+);
+```
 Specifying the tslint module
 ----------------------------
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-tslint",
   "preferGlobal": false,
-  "version": "6.1.3",
+  "version": "6.1.3-sap",
   "author": "Panu Horsmalahti <panu.horsmalahti@iki.fi>",
   "description": "TypeScript linter Gulp plugin",
   "contributors": [

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -149,8 +149,16 @@ gulp.task("invalid-noemit", function() {
         }));
 });
 
-// Example on output to file
 gulp.task("output-to-file", function() {
+    return gulp.src(["invalid.ts", "invalid2.ts"])
+        .pipe(tslint({
+            formatter: "checkstyle"
+        }))
+        .pipe(tslint.report({'emitError': false, 'out' : "target/checkstyle-report.xml"}));
+});
+
+// Example on output to file
+gulp.task("output-to-file-example", function() {
     return gulp.src(["invalid.ts", "invalid2.ts"])
         .pipe(tslint({
             formatter: "prose"


### PR DESCRIPTION
Hi, 

we need the tslint results in a file on our build server. 
Instead of using the example in test/gulpfile.js I enhanced the report options with a filename in property `out`.

Tobias