### PR TITLE
Update README.md to clarify over when the file contents are read

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,19 @@ npm install --save-dev gulp-tslint
 The `tslint` module is a peer dependency of `gulp-tslint`, which allows you to update tslint independently from gulp-tslint.
 
 Usage:
+
 ```typescript
-// Importing in ES6
-import tslint from "gulp-tslint";
-
-// or requiring in ES5
-var tslint = require("gulp-tslint");
-
 gulp.task("tslint", () =>
+    // Note: Requiring/Importing gulp-tslint from within the gulp task ensures that that files are re-read
+    // so that is this is used in a 'watch' task the files do not appear to be cached. If this isn't the use-case
+    // the Require/Import statements below can be moved outside the gulp task.
+
+    // Importing in ES6
+    import tslint from "gulp-tslint";
+
+    // or requiring in ES5
+    var tslint = require("gulp-tslint");
+
     gulp.src("source.ts")
         .pipe(tslint({
             formatter: "verbose"

--- a/README.md
+++ b/README.md
@@ -17,19 +17,14 @@ npm install --save-dev gulp-tslint
 The `tslint` module is a peer dependency of `gulp-tslint`, which allows you to update tslint independently from gulp-tslint.
 
 Usage:
-
 ```typescript
+// Importing in ES6
+import tslint from "gulp-tslint";
+
+// or requiring in ES5
+var tslint = require("gulp-tslint");
+
 gulp.task("tslint", () =>
-    // Note: Requiring/Importing gulp-tslint from within the gulp task ensures that that files are re-read
-    // so that is this is used in a 'watch' task the files do not appear to be cached. If this isn't the use-case
-    // the Require/Import statements below can be moved outside the gulp task.
-
-    // Importing in ES6
-    import tslint from "gulp-tslint";
-
-    // or requiring in ES5
-    var tslint = require("gulp-tslint");
-
     gulp.src("source.ts")
         .pipe(tslint({
             formatter: "verbose"
@@ -165,6 +160,10 @@ Type checked rules require a TypeScript program object to be provided to the lin
 ```javascript
 var gulpTslint = require("gulp-tslint");
 var tslint = require("tslint");
+
+// NOTE: Ensure 'createProgram' is called inside the gulp task else the contents of the files will be cached
+// if this tasks is called again (eg. as part of a 'watch' task).
+gulp.task('lint', function() {
 var program = tslint.createProgram("./tsconfig.json");
 
 // ...


### PR DESCRIPTION
The comment clarifies where gulp-tslint should be instantiated and the consequences of doing it outside vs inside the gulp task.