### PR TITLE
Clarification on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ var tslint = require("tslint");
 gulp.task('lint', function() {
 var program = tslint.Linter.createProgram("./tsconfig.json");
 
-// ...
-.pipe(gulpTslint({ program }))
+gulp.src('src/**/*.ts', { base: '.' })
+  .pipe(gulpTslint({ program }))
 ```
 
 All default tslint options


### PR DESCRIPTION
As mentionned in #71, using the program option for type-checking can lead to `Invalid source file: xxx.ts. Ensure that the files supplied to lint have a .ts, .tsx, .js or .jsx extension.`

Using the base option of gulp.src corrects it, thought mentionning it in README can save some time for users.