### PR TITLE
#106: skip directories while reporting errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,19 +134,21 @@ tslintPlugin.report = function (options) {
     var totalReported = 0;
     // Log formatted output for each file individually
     var reportFailures = function (file) {
-        var failureCount = file.tslint.failureCount;
-        if (failureCount > 0) {
-            errorFiles.push(file);
-            Array.prototype.push.apply(allFailures, file.tslint.failures);
-            if (options.reportLimit <= 0 || (options.reportLimit && options.reportLimit > totalReported)) {
-                if (file.tslint.output !== undefined) {
-                    console.log(file.tslint.output);
-                }
-                totalReported += failureCount;
-                if (options.reportLimit > 0 &&
-                    options.reportLimit <= totalReported) {
-                    log("More than " + options.reportLimit
-                        + " failures reported. Turning off reporter.");
+        if (file.tslint) {
+            var failureCount = file.tslint.failureCount;
+            if (failureCount > 0) {
+                errorFiles.push(file);
+                Array.prototype.push.apply(allFailures, file.tslint.failures);
+                if (options.reportLimit <= 0 || (options.reportLimit && options.reportLimit > totalReported)) {
+                    if (file.tslint.output !== undefined) {
+                        console.log(file.tslint.output);
+                    }
+                    totalReported += failureCount;
+                    if (options.reportLimit > 0 &&
+                        options.reportLimit <= totalReported) {
+                        log("More than " + options.reportLimit
+                            + " failures reported. Turning off reporter.");
+                    }
                 }
             }
         }

--- a/index.ts
+++ b/index.ts
@@ -198,22 +198,25 @@ tslintPlugin.report = function(options?: ReportOptions) {
 
     // Log formatted output for each file individually
     const reportFailures = function(file: TslintFile) {
-        const failureCount = file.tslint.failureCount;
 
-        if (failureCount > 0) {
-            errorFiles.push(file);
-            Array.prototype.push.apply(allFailures, file.tslint.failures);
+        if (file.tslint) {
+            const failureCount = file.tslint.failureCount;
 
-            if (options.reportLimit <= 0 || (options.reportLimit && options.reportLimit > totalReported)) {
-                if (file.tslint.output !== undefined) {
-                    console.log(file.tslint.output);
-                }
-                totalReported += failureCount;
+            if (failureCount > 0) {
+                errorFiles.push(file);
+                Array.prototype.push.apply(allFailures, file.tslint.failures);
 
-                if (options.reportLimit > 0 &&
-                    options.reportLimit <= totalReported) {
-                    log("More than " + options.reportLimit
-                        + " failures reported. Turning off reporter.");
+                if (options.reportLimit <= 0 || (options.reportLimit && options.reportLimit > totalReported)) {
+                    if (file.tslint.output !== undefined) {
+                        console.log(file.tslint.output);
+                    }
+                    totalReported += failureCount;
+
+                    if (options.reportLimit > 0 &&
+                        options.reportLimit <= totalReported) {
+                        log("More than " + options.reportLimit
+                            + " failures reported. Turning off reporter.");
+                    }
                 }
             }
         }


### PR DESCRIPTION
if source was a filter like **/*, errors occur when try to get file.tslint

Fixes this: https://github.com/panuhorsmalahti/gulp-tslint/issues/106