### PR TITLE
Format and colorize output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gulp-tslint",
+  "name": "@5minds/gulp-tslint",
   "preferGlobal": false,
-  "version": "7.1.0",
+  "version": "7.1.1",
   "author": "Panu Horsmalahti <panu.horsmalahti@iki.fi>",
   "description": "TypeScript linter Gulp plugin",
   "contributors": [
@@ -27,6 +27,7 @@
     "lint"
   ],
   "dependencies": {
+    "columnify": "^1.5.4",
     "gulp-util": "~3.0.8",
     "map-stream": "~0.1.0",
     "through": "~2.3.8"
@@ -47,7 +48,7 @@
     "node": ">= 4"
   },
   "bugs": {
-    "url" : "https://github.com/panuhorsmalahti/gulp-tslint/issues"
+    "url": "https://github.com/panuhorsmalahti/gulp-tslint/issues"
   },
   "homepage": "https://github.com/panuhorsmalahti/gulp-tslint",
   "typings": "index"


### PR DESCRIPTION
The current output could visually benefit by leaving out repetitive information, using colors to highlight information and rearranging the structure with columns.
## Before
<img width="870" alt="previous" src="https://cloud.githubusercontent.com/assets/21304781/23069516/084ee7c0-f528-11e6-97dd-8260cce024f7.png">

## After
<img width="759" alt="after" src="https://cloud.githubusercontent.com/assets/21304781/23069520/0ac0486e-f528-11e6-96cf-913de04b45fb.png">
