### PR TITLE
Add `allowWarnings` option to print warnings without failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,23 @@ gulp.task("tslint", () =>
 );
 ```
 
+Allowing Warnings
+-----------------
+
+TSLint 5.0 introduced support for a "warning" severity for linting errors.  By default, warnings cause `gulp-tslint` to emit an error to maintain backwards-compatibility with previous versions.  To let the build succeed in the presence of warnings, use the `allowWarnings` report option.
+
+```javascript
+gulp.task("tslint", () =>
+    gulp.src("input.ts")
+        .pipe(tslint({
+            formatter: "prose"
+        }))
+        .pipe(tslint.report({
+            allowWarnings: true
+        }))
+);
+```
+
 Specifying the tslint module
 ----------------------------
 
@@ -193,7 +210,8 @@ All default report options
 const reportOptions = {
     emitError: true,
     reportLimit: 0,
-    summarizeFailureOutput: false
+    summarizeFailureOutput: false,
+    allowWarnings: false
 };
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export interface ReportOptions {
     emitError?: boolean;
     reportLimit?: number;
     summarizeFailureOutput?: boolean;
+    allowWarnings?: boolean;
 }
 export interface TslintFile {
     tslint: any;
@@ -24,6 +25,7 @@ export interface TslintFile {
 export interface TslintPlugin {
     (pluginOptions?: PluginOptions): any;
     report: (options?: ReportOptions) => any;
+    pluginOptions: PluginOptions;
 }
 /**
  * Main plugin function

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -411,3 +411,36 @@ gulp.task("custom-rules-file", function() {
         }))
         .pipe(tslint.report());
 });
+
+
+// Should report warnings and succeed since warnings are allowed.
+gulp.task("warnings-allowed", function() {
+    return gulp.src("warnings/warnings.ts")
+        .pipe(tslint({
+            configuration: "warnings/tslint.json",
+            formatter: "verbose"
+        }))
+        .pipe(tslint.report({
+            allowWarnings: true
+        }));
+});
+
+// Should report warnings and fail since warnings aren't allowed.
+gulp.task("warnings-not-allowed", function() {
+    return gulp.src("warnings/warnings.ts")
+        .pipe(tslint({
+            configuration: "warnings/tslint.json",
+            formatter: "verbose"
+        }))
+        .pipe(tslint.report());
+});
+
+// Should report errors and warnings and fail since errors occur.
+gulp.task("warnings-and-errors", function() {
+    return gulp.src("warnings-and-errors/warnings-and-errors.ts")
+        .pipe(tslint({
+            configuration: "warnings-and-errors/tslint.json",
+            formatter: "verbose"
+        }))
+        .pipe(tslint.report());
+});

--- a/test/warnings-and-errors/tslint.json
+++ b/test/warnings-and-errors/tslint.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+      "semicolon": { "severity": "warn" },
+      "no-eval": true
+  }
+}

--- a/test/warnings-and-errors/warnings-and-errors.ts
+++ b/test/warnings-and-errors/warnings-and-errors.ts
@@ -1,0 +1,2 @@
+let noSemiColon = "this line lacks a semicolon"
+eval("2 + 3");

--- a/test/warnings/tslint.json
+++ b/test/warnings/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+      "semicolon": { "severity": "warn" }
+  }
+}

--- a/test/warnings/warnings.ts
+++ b/test/warnings/warnings.ts
@@ -1,0 +1,1 @@
+let noSemiColon = "this line lacks a semicolon"


### PR DESCRIPTION
TSLint 5.0 supports a "severity" field, allowing rules to either be
an error, a warning, or completely disabled.  The new `allowWarnings`
option to `gulpTslint.report` allows a build to succeed while still
printing formatted warnings.

fixes #116