### PR TITLE
Moving tslint linter object outside of map loop

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -116,8 +116,6 @@ const proseErrorFormat = function(failure: RuleFailure) {
  * @returns {any}
  */
 const tslintPlugin = <TslintPlugin> function(pluginOptions?: PluginOptions) {
-    let loader: any;
-
     // If user options are undefined, set an empty options object
     if (!pluginOptions) {
         pluginOptions = {};


### PR DESCRIPTION
Changes for #125.
I checked all gulp tasks in test folder, all of them are working the same way as in master.
Please note, that `gulp invalid-json-rules` fails in master, too :) And some of the rules (like "forof") now require type-checking, so that output does not really match what's written above the respective gulp-task.
 