### PR TITLE
refactored the type definition to use a namespace and function, both …

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,37 +1,49 @@
 /// <reference types="node" />
-export interface PluginOptions {
-    configuration?: any;
-    fix?: boolean;
-    formatter?: string | Function;
-    formattersDirectory?: string;
-    rulesDirectory?: string;
-    tslint?: any;
-    program?: any;
+
+declare namespace tslintPlugin {
+
+	interface PluginOptions {
+		configuration?: any;
+		fix?: boolean;
+		formatter?: string | Function;
+		formattersDirectory?: string;
+		rulesDirectory?: string;
+		tslint?: any;
+		program?: any;
+	}
+
+	interface ReportOptions {
+		emitError?: boolean;
+		reportLimit?: number;
+		summarizeFailureOutput?: boolean;
+		allowWarnings?: boolean;
+	}
+
+	interface TslintFile {
+		tslint: any;
+		path: string;
+		relative: string;
+		contents: Buffer | any;
+		isStream(): boolean;
+		isNull(): boolean;
+	}
+
+	interface TslintPlugin {
+		(pluginOptions?: PluginOptions): any;
+		report: (options?: ReportOptions) => any;
+		pluginOptions: PluginOptions;
+	}
+
+	function report(options?: ReportOptions): any;
+    const pluginOptions: PluginOptions;
 }
-export interface ReportOptions {
-    emitError?: boolean;
-    reportLimit?: number;
-    summarizeFailureOutput?: boolean;
-    allowWarnings?: boolean;
-}
-export interface TslintFile {
-    tslint: any;
-    path: string;
-    relative: string;
-    contents: Buffer | any;
-    isStream(): boolean;
-    isNull(): boolean;
-}
-export interface TslintPlugin {
-    (pluginOptions?: PluginOptions): any;
-    report: (options?: ReportOptions) => any;
-    pluginOptions: PluginOptions;
-}
+
 /**
  * Main plugin function
  * @param {PluginOptions} [pluginOptions] contains the options for gulp-tslint.
  * Optional.
  * @returns {any}
  */
-declare const tslintPlugin: TslintPlugin;
-export default tslintPlugin;
+declare function tslintPlugin(pluginOptions?: tslintPlugin.PluginOptions): any;
+
+export = tslintPlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,42 @@
 /// <reference types="node" />
 
-import { PluginOptions, ReportOptions, TslintFile } from "./index"
-import * as tslintPlugin from "./index"
+declare namespace tslintPlugin {
+
+	interface PluginOptions {
+		configuration?: any;
+		fix?: boolean;
+		formatter?: string | Function;
+		formattersDirectory?: string;
+		rulesDirectory?: string;
+		tslint?: any;
+		program?: any;
+	}
+
+	interface ReportOptions {
+		emitError?: boolean;
+		reportLimit?: number;
+		summarizeFailureOutput?: boolean;
+		allowWarnings?: boolean;
+	}
+
+	interface TslintFile {
+		tslint: any;
+		path: string;
+		relative: string;
+		contents: Buffer | any;
+		isStream(): boolean;
+		isNull(): boolean;
+	}
+
+	interface TslintPlugin {
+		(pluginOptions?: PluginOptions): any;
+		report: (options?: ReportOptions) => any;
+		pluginOptions: PluginOptions;
+	}
+
+	function report(options?: ReportOptions): any;
+    const pluginOptions: PluginOptions;
+}
 
 /**
  * Main plugin function
@@ -9,5 +44,6 @@ import * as tslintPlugin from "./index"
  * Optional.
  * @returns {any}
  */
+declare function tslintPlugin(pluginOptions?: tslintPlugin.PluginOptions): any;
 
 export = tslintPlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,42 +1,7 @@
 /// <reference types="node" />
 
-declare namespace tslintPlugin {
-
-	interface PluginOptions {
-		configuration?: any;
-		fix?: boolean;
-		formatter?: string | Function;
-		formattersDirectory?: string;
-		rulesDirectory?: string;
-		tslint?: any;
-		program?: any;
-	}
-
-	interface ReportOptions {
-		emitError?: boolean;
-		reportLimit?: number;
-		summarizeFailureOutput?: boolean;
-		allowWarnings?: boolean;
-	}
-
-	interface TslintFile {
-		tslint: any;
-		path: string;
-		relative: string;
-		contents: Buffer | any;
-		isStream(): boolean;
-		isNull(): boolean;
-	}
-
-	interface TslintPlugin {
-		(pluginOptions?: PluginOptions): any;
-		report: (options?: ReportOptions) => any;
-		pluginOptions: PluginOptions;
-	}
-
-	function report(options?: ReportOptions): any;
-    const pluginOptions: PluginOptions;
-}
+import { PluginOptions, ReportOptions, TslintFile } from "./index"
+import * as tslintPlugin from "./index"
 
 /**
  * Main plugin function
@@ -44,6 +9,5 @@ declare namespace tslintPlugin {
  * Optional.
  * @returns {any}
  */
-declare function tslintPlugin(pluginOptions?: tslintPlugin.PluginOptions): any;
 
 export = tslintPlugin;


### PR DESCRIPTION
…with the same

name, as this fixes the type defs for me when working with ts-node and also seems
to be the most common and stable way of defining a type definition for a library
that you use as either a function or an object.