### PR TITLE
types should be dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "lint"
   ],
   "dependencies": {
-    "@types/gulp-util": "^3.0.31",
-    "@types/node": "^7.0.18",
-    "@types/through": "0.0.28",
     "gulp-util": "~3.0.8",
     "map-stream": "~0.0.7",
     "through": "~2.3.8"
   },
   "analyze": true,
   "devDependencies": {
+    "@types/gulp-util": "^3.0.31",
+    "@types/node": "^7.0.18",
+    "@types/through": "0.0.28",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-typescript": "^3.1.6",


### PR DESCRIPTION
Fix for https://github.com/panuhorsmalahti/gulp-tslint/issues/126

This issue broke my react-native build as I ended up pulling in the types/node types which conflicted with the types/react-native types. Easy enough to fix though :)