### PR TITLE
Fix broken tests

### DIFF
--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -192,14 +192,23 @@ gulp.task("invalid-summarize-no-emit", function() {
 // Should not emit errors
 gulp.task("custom-tslint-no-errors", function() {
     // A mocked tslint module
-    var mocked = function() {
+    var mocked = {};
+    mocked.Linter = function() {
         this.lint = function() {
-            return {
-                output: "[]"
+            this.result = {
+                errorCount: 0,
+                failures: [],
+                format: "prose",
+                output: "\n",
+                warningCount: 0 
             }
         };
+        this.getResult = () => {
+            return this.result;
+        }
     };
-    mocked.findConfiguration = function() { return {}; };
+    mocked.Configuration = {};
+    mocked.Configuration.findConfiguration = function() { return {}; };
 
     return gulp.src("invalid.ts")
         .pipe(tslint({
@@ -214,19 +223,26 @@ gulp.task("custom-tslint-errors", function() {
     // A mocked tslint module
     var mocked = {};
     mocked.Linter = function() {
+        var result;
         this.lint = function() {
-            return {
-                output: JSON.stringify([{
-                    name: "name",
-                    ruleName: "ruleName",
-                    startPosition: {
-                        line: 0,
-                        character: 0
-                    },
-                    failure: "failure"
-                }])
+            result = {
+                errorCount: 1,
+                failures: 
+                [ {
+                    fileName: '/Users/test/gulp-tslint/test/invalid.ts',
+                    ruleSeverity: 'ERROR',
+                    getFileName: () => "/Users/test/gulp-tslint/test/invalid.ts",
+                    getFailure: () => "Missing semicolon",
+                    getStartPosition: () => ({ getLineAndCharacter: () => ({ line: 10, character: 99 }) })
+                    }],
+                format: 'prose',
+                output: '\nERROR: /Users/test/Projects/gulp-tslint/test/invalid.ts[1, 33]: Missing semicolon\n',
+                warningCount: 0 
             }
         };
+        this.getResult = function() {
+            return result;
+        }
     };
     mocked.Configuration = {};
     mocked.Configuration.findConfiguration = function() { return {}; };


### PR DESCRIPTION
Tests custom-tslint-no-errors and custom-tslint-errors throw exceptions. This PR fixes their implementation