### PR TITLE
Moved to ansi-colors. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 // Requires
-var chalk_1 = require("chalk");
+var colors = require("ansi-colors");
 var fancyLog = require("fancy-log");
 var TSLint = require("tslint");
 var through = require("through");
@@ -43,9 +43,9 @@ function getTslint(options) {
  * Leave empty for the default logging type.
  */
 function log(message, level) {
-    var prefix = "[" + chalk_1.default.cyan("gulp-tslint") + "]";
+    var prefix = "[" + colors.cyan("gulp-tslint") + "]";
     if (level === "error") {
-        fancyLog(prefix, chalk_1.default.red("error"), message);
+        fancyLog(prefix, colors.red("error"), message);
     }
     else {
         fancyLog(prefix, message);
@@ -98,6 +98,7 @@ var tslintPlugin = function (pluginOptions) {
         var configuration = (pluginOptions.configuration === null ||
             pluginOptions.configuration === undefined ||
             isString(pluginOptions.configuration))
+            // Configuration can be a file path or null, if it's unknown
             ? linter.Configuration.findConfiguration(pluginOptions.configuration || null, file.path).results
             : pluginOptions.configuration;
         tslint.lint(file.path, file.contents.toString("utf8"), configuration);

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@
 "use strict";
 
 // Requires
-import chalk from "chalk";
+import * as colors from "ansi-colors";
 import * as fancyLog from "fancy-log";
 import * as TSLint from "tslint";
 import { RuleFailure } from "tslint/lib/language/rule/rule";
@@ -86,10 +86,10 @@ function getTslint(options: PluginOptions) {
  * Leave empty for the default logging type.
  */
 function log(message: string, level?: string) {
-    const prefix = "[" + chalk.cyan("gulp-tslint") + "]";
+    const prefix = "[" + colors.cyan("gulp-tslint") + "]";
 
     if (level === "error") {
-      fancyLog(prefix, chalk.red("error"), message);
+      fancyLog(prefix, colors.red("error"), message);
     } else {
       fancyLog(prefix, message);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,15 @@
 {
   "name": "gulp-tslint",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/ansi-colors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ansi-colors/-/ansi-colors-1.0.0.tgz",
+      "integrity": "sha512-8vHIQwoOC6+cH8detpxD3rYojMJfDmVA7TZLmhiDHyvkxTvd+FpEQSPcP4sLLizoMCODjlLy1X3M0DK+1VLzLQ==",
+      "dev": true
+    },
     "@types/fancy-log": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@types/fancy-log/-/fancy-log-1.3.0.tgz",
@@ -50,6 +56,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "dev": true,
       "requires": {
         "color-convert": "1.9.1"
       }
@@ -269,6 +276,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
       "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+      "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -278,12 +286,14 @@
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
           "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -413,6 +423,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -420,7 +431,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-support": {
       "version": "1.1.3",
@@ -620,7 +632,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@types/fancy-log": "1.3.0",
-    "chalk": "2.3.1",
+    "ansi-colors": "^1.0.1",
     "fancy-log": "1.3.2",
     "map-stream": "~0.0.7",
     "plugin-error": "1.0.1",
@@ -36,6 +36,7 @@
   },
   "analyze": true,
   "devDependencies": {
+    "@types/ansi-colors": "^1.0.0",
     "@types/node": "^7.0.18",
     "@types/through": "0.0.29",
     "gulp": "^3.9.1",


### PR DESCRIPTION
As mentioned at #140, chalk is filled to the brim with functionality that isn't used here, and `ansi-colors` is a common dependency of Gulp v4 anyway (likely the reason for its recommendation in the `gulp-util` migration guide). 