### PR TITLE
Use formattersDirectory in tslintPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ tslintPlugin.report = function (options) {
             else if (options.allowWarnings && file.tslint.warningCount > 0) {
                 // Íf only warnings were emitted, format and print them
                 // Figure out which formatter the user requested in `tslintPlugin()` and construct one
-                var formatterConstructor = TSLint.findFormatter(tslintPlugin.pluginOptions.formatter);
+                var formatterConstructor = TSLint.findFormatter(tslintPlugin.pluginOptions.formatter, tslintPlugin.pluginOptions.formattersDirectory);
                 var formatter = new formatterConstructor();
                 // Get just the warnings
                 var warnings = file.tslint.failures.filter(function (failure) { return failure.getRuleSeverity() === "warning"; });

--- a/index.ts
+++ b/index.ts
@@ -232,7 +232,10 @@ tslintPlugin.report = function(options?: ReportOptions) {
                 // Íf only warnings were emitted, format and print them
 
                 // Figure out which formatter the user requested in `tslintPlugin()` and construct one
-                const formatterConstructor = TSLint.findFormatter(tslintPlugin.pluginOptions.formatter as string);
+                const formatterConstructor = TSLint.findFormatter(
+                    tslintPlugin.pluginOptions.formatter as string,
+                    tslintPlugin.pluginOptions.formattersDirectory as string,
+                );
                 const formatter = new formatterConstructor();
 
                 // Get just the warnings


### PR DESCRIPTION
Formatters that needed to be looked up with formattersDirectory caused crashes in `report`. This PR passes formattersDirectory through to findFormatter in `report` to stop this crash.
