### PR TITLE
Fix plugin return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,8 +23,8 @@ export interface TslintFile {
     isNull(): boolean;
 }
 export interface TslintPlugin {
-    (pluginOptions?: PluginOptions): any;
-    report: (options?: ReportOptions) => any;
+    (pluginOptions?: PluginOptions): NodeJS.ReadWriteStream;
+    report: (options?: ReportOptions) => NodeJS.ReadWriteStream;
     pluginOptions: PluginOptions;
 }
 /**

--- a/index.ts
+++ b/index.ts
@@ -43,8 +43,8 @@ export interface TslintFile /* extends vinyl.File */ {
 }
 
 export interface TslintPlugin {
-    (pluginOptions?: PluginOptions): any;
-    report: (options?: ReportOptions) => any;
+    (pluginOptions?: PluginOptions): NodeJS.ReadWriteStream;
+    report: (options?: ReportOptions) => NodeJS.ReadWriteStream;
     pluginOptions: PluginOptions;
 }
 


### PR DESCRIPTION
Plugin returns `NodeJS.ReadWriteStream`, but interface return type is `any`.
Because `pipe()` is generic, it's return type inferred from it's parameters,
so if parameter is `any` intellisense doesn't show `pipe()` after piping to
**gulp-tslint**.